### PR TITLE
BGMの追加

### DIFF
--- a/src/Game/Common/Fade.cpp
+++ b/src/Game/Common/Fade.cpp
@@ -32,9 +32,9 @@ namespace Game
 		_fade = FADE_TIME;
 		_dir = -1;
 		_alpha = 0;
-		_red = 0;
-		_blue = 0;
-		_green = 0;
+		_red = 50;
+		_blue = 50;
+		_green = 50;
 		_render = this->GetAttachedObject()->FindBehaviour<GameEngine::Behaviour::UIRenderer>();
 
 	}

--- a/src/Game/GameScene/Scene/Stage1Scene/Stage1Scene.cpp
+++ b/src/Game/GameScene/Scene/Stage1Scene/Stage1Scene.cpp
@@ -7,7 +7,7 @@
 #include "../../../Common/Pipeline/Echo.h"
 #include "../StageManager.h"
 #include "../../../Common/Fade.h"
-#include "../../Behavior/GimmickFactory.h"
+#include "../../Behaviour/GimmickFactory.h"
 
 namespace Game { namespace GameScene { namespace Scene
 {
@@ -45,15 +45,23 @@ namespace Game { namespace GameScene { namespace Scene
 		
         Behaviour::GimmickFactory::InstantiateBell(&D3DXVECTOR3(0.0f, 0.0f, 10.0f), &D3DXVECTOR3(0.0f, 0.0f, 0.0f));
 
+		// BGM・SE用
+		GameEngine::GameObject* stageSoundObject = GameEngine::GameObject::Instantiate();
+		auto stageSoundPlay = new GameEngine::Behaviour::SoundPlay();
+		stageSoundPlay->SetSound(GameEngine::Sound::Sound::CreateFromWaveFile("./data/sound/game_honpen.wav", XAUDIO2_LOOP_INFINITE));
+		stageSoundObject->AddBehaviour(stageSoundPlay);
+		stageSoundPlay->Play();
+
+
 		// フェード用
-		GameEngine::GameObject* FadeObject = GameEngine::GameObject::Instantiate();
-		FadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
-		FadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
+		GameEngine::GameObject* fadeObject = GameEngine::GameObject::Instantiate();
+		fadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
+		fadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
 		auto fade = new Game::Fade();
-		auto FadeRenderer = new GameEngine::Behaviour::UIRenderer();
-		FadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
-		FadeObject->AddBehaviour(FadeRenderer);
-		FadeObject->AddBehaviour(fade);
+		auto fadeRenderer = new GameEngine::Behaviour::UIRenderer();
+		fadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
+		fadeObject->AddBehaviour(fadeRenderer);
+		fadeObject->AddBehaviour(fade);
 
 		return false;
 	}

--- a/src/Game/GameScene/Scene/Stage2Scene/Stage2Scene.cpp
+++ b/src/Game/GameScene/Scene/Stage2Scene/Stage2Scene.cpp
@@ -43,15 +43,22 @@ namespace Game { namespace GameScene { namespace Scene
 		object2->AddBehaviour(meshRenderer);
 		
 
+		// BGM・SE用
+		GameEngine::GameObject* stageSoundObject = GameEngine::GameObject::Instantiate();
+		auto stageSoundPlay = new GameEngine::Behaviour::SoundPlay();
+		stageSoundPlay->SetSound(GameEngine::Sound::Sound::CreateFromWaveFile("./data/sound/game_honpen.wav", XAUDIO2_LOOP_INFINITE));
+		stageSoundObject->AddBehaviour(stageSoundPlay);
+		stageSoundPlay->Play();
+
 		// フェード用
-		GameEngine::GameObject* FadeObject = GameEngine::GameObject::Instantiate();
-		FadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
-		FadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
+		GameEngine::GameObject* fadeObject = GameEngine::GameObject::Instantiate();
+		fadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
+		fadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
 		auto fade = new Game::Fade();
-		auto FadeRenderer = new GameEngine::Behaviour::UIRenderer();
-		FadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
-		FadeObject->AddBehaviour(FadeRenderer);
-		FadeObject->AddBehaviour(fade);
+		auto fadeRenderer = new GameEngine::Behaviour::UIRenderer();
+		fadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
+		fadeObject->AddBehaviour(fadeRenderer);
+		fadeObject->AddBehaviour(fade);
 
 		return false;
 	}

--- a/src/Game/GameScene/Scene/Stage3Scene/Stage3Scene.cpp
+++ b/src/Game/GameScene/Scene/Stage3Scene/Stage3Scene.cpp
@@ -42,15 +42,23 @@ namespace Game { namespace GameScene { namespace Scene
 		meshRenderer->SetMesh(std::shared_ptr<GameEngine::Resource::Mesh::IMesh>(new GameEngine::Resource::Mesh::MeshD3DX(TEXT("./data/model/stage.x"))));
 		object2->AddBehaviour(meshRenderer);
 		
+
+		// BGM・SE用
+		GameEngine::GameObject* stageSoundObject = GameEngine::GameObject::Instantiate();
+		auto stageSoundPlay = new GameEngine::Behaviour::SoundPlay();
+		stageSoundPlay->SetSound(GameEngine::Sound::Sound::CreateFromWaveFile("./data/sound/game_honpen.wav", XAUDIO2_LOOP_INFINITE));
+		stageSoundObject->AddBehaviour(stageSoundPlay);
+		stageSoundPlay->Play();
+
 		// フェード用
-		GameEngine::GameObject* FadeObject = GameEngine::GameObject::Instantiate();
-		FadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
-		FadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
+		GameEngine::GameObject* fadeObject = GameEngine::GameObject::Instantiate();
+		fadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
+		fadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
 		auto fade = new Game::Fade();
-		auto FadeRenderer = new GameEngine::Behaviour::UIRenderer();
-		FadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
-		FadeObject->AddBehaviour(FadeRenderer);
-		FadeObject->AddBehaviour(fade);
+		auto fadeRenderer = new GameEngine::Behaviour::UIRenderer();
+		fadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
+		fadeObject->AddBehaviour(fadeRenderer);
+		fadeObject->AddBehaviour(fade);
 
 		return false;
 	}

--- a/src/Game/GameScene/Scene/TutorialScene/TutorialScene.cpp
+++ b/src/Game/GameScene/Scene/TutorialScene/TutorialScene.cpp
@@ -43,19 +43,24 @@ namespace Game { namespace GameScene { namespace Scene
 		meshRenderer->SetMesh(std::shared_ptr<GameEngine::Resource::Mesh::IMesh>(new GameEngine::Resource::Mesh::MeshD3DX(TEXT("./data/model/stage.x"))));
 		object2->AddBehaviour(meshRenderer);
 
-		GameEngine::GameObject* object4 = GameEngine::GameObject::Instantiate();
+		// マネージャー用
+		GameEngine::GameObject* tutorialManagerObject = GameEngine::GameObject::Instantiate();
 		auto tutorialmanager = new Game::GameScene::Scene::TutorialManager();
-		object4->AddBehaviour(tutorialmanager);
+		tutorialManagerObject->AddBehaviour(tutorialmanager);
+		auto tutorialManagerSoundPlay = new GameEngine::Behaviour::SoundPlay();
+		tutorialManagerSoundPlay->SetSound(GameEngine::Sound::Sound::CreateFromWaveFile("./data/sound/game_honpen.wav", XAUDIO2_LOOP_INFINITE));
+		tutorialManagerObject->AddBehaviour(tutorialManagerSoundPlay);
+		tutorialManagerSoundPlay->Play();
 
 		// フェード用
-		GameEngine::GameObject* FadeObject = GameEngine::GameObject::Instantiate();
-		FadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
-		FadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
+		GameEngine::GameObject* fadeObject = GameEngine::GameObject::Instantiate();
+		fadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
+		fadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
 		auto fade = new Game::Fade();
-		auto FadeRenderer = new GameEngine::Behaviour::UIRenderer();
-		FadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
-		FadeObject->AddBehaviour(FadeRenderer);
-		FadeObject->AddBehaviour(fade);
+		auto fadeRenderer = new GameEngine::Behaviour::UIRenderer();
+		fadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
+		fadeObject->AddBehaviour(fadeRenderer);
+		fadeObject->AddBehaviour(fade);
 
 		
 

--- a/src/Game/ResultScene/GameClearScene/GameClearScene.cpp
+++ b/src/Game/ResultScene/GameClearScene/GameClearScene.cpp
@@ -28,46 +28,52 @@ namespace Game { namespace ResultScene
 
 		using Texture = GameEngine::Resource::Texture;
 		using ResourceManager = GameEngine::Resource::ResourceManager;
-		GameEngine::GameObject* ManagerObject = GameEngine::GameObject::Instantiate();
+
+		// マネージャー用
+		GameEngine::GameObject* resultManagerObject = GameEngine::GameObject::Instantiate();
 		auto resultmanager = new Game::ResultManager();
-		ManagerObject->AddBehaviour(resultmanager);
+		auto resultManagerSoundPlay = new GameEngine::Behaviour::SoundPlay();
+		resultManagerSoundPlay->SetSound(GameEngine::Sound::Sound::CreateFromWaveFile("./data/sound/game_clear.wav", XAUDIO2_LOOP_INFINITE));
+		resultManagerObject->AddBehaviour(resultmanager);
+		resultManagerObject->AddBehaviour(resultManagerSoundPlay);
+		resultManagerSoundPlay->Play();
 
+		// ゲームクリア画面の背景用
+		GameEngine::GameObject* backgroundObject = GameEngine::GameObject::Instantiate();
+		backgroundObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
+		backgroundObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
+		auto backgroundRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/GAME_CLEAR_BG.png"));
+		backgroundRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+		backgroundObject->AddBehaviour(backgroundRenderer);
 
-		GameEngine::GameObject* BackgroundObject = GameEngine::GameObject::Instantiate();
-		BackgroundObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
-		BackgroundObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
-		auto backGroundRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/GAME_CLEAR_BG.png"));
-		backGroundRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
-		BackgroundObject->AddBehaviour(backGroundRenderer);
-
-
-		GameEngine::GameObject* GameClearObject = GameEngine::GameObject::Instantiate();
-		GameClearObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 200.0f, 0.0f));
-		GameClearObject->GetTransform()->SetScale(&D3DXVECTOR3(600.0f, 150.0f, 50.0f));
-		auto GameClearRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/GAME_CLEAR.png"));
-		GameClearRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
-		GameClearObject->AddBehaviour(GameClearRenderer);
+		// ゲームクリアの文字用
+		GameEngine::GameObject* gameClearObject = GameEngine::GameObject::Instantiate();
+		gameClearObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 200.0f, 0.0f));
+		gameClearObject->GetTransform()->SetScale(&D3DXVECTOR3(600.0f, 150.0f, 50.0f));
+		auto gameClearRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/STAGE_CLEAR.png"));
+		gameClearRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+		gameClearObject->AddBehaviour(gameClearRenderer);
 
 
 		// PushEnter用
-		GameEngine::GameObject* PushEnterObject = GameEngine::GameObject::Instantiate();
-		PushEnterObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 450.0f, 0.0f));
-		PushEnterObject->GetTransform()->SetScale(&D3DXVECTOR3(400.0f, 300.0f, 50.0f));
+		GameEngine::GameObject* pushenterObject = GameEngine::GameObject::Instantiate();
+		pushenterObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 400.0f, 0.0f));
+		pushenterObject->GetTransform()->SetScale(&D3DXVECTOR3(400.0f, 300.0f, 50.0f));
 		auto flash = new Game::Flash();
-		auto PushEnterRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/pushenter.png"));
-		PushEnterObject->AddBehaviour(flash);
-		PushEnterRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
-		PushEnterObject->AddBehaviour(PushEnterRenderer);
+		auto pushenterRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/pushenter.png"));
+		pushenterObject->AddBehaviour(flash);
+		pushenterRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+		pushenterObject->AddBehaviour(pushenterRenderer);
 
 		// フェード用
-		GameEngine::GameObject* FadeObject = GameEngine::GameObject::Instantiate();
-		FadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
-		FadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
+		GameEngine::GameObject* fadeObject = GameEngine::GameObject::Instantiate();
+		fadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
+		fadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
 		auto fade = new Game::Fade();
-		auto FadeRenderer = new GameEngine::Behaviour::UIRenderer();
-		FadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
-		FadeObject->AddBehaviour(FadeRenderer);
-		FadeObject->AddBehaviour(fade);
+		auto fadeRenderer = new GameEngine::Behaviour::UIRenderer();
+		fadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
+		fadeObject->AddBehaviour(fadeRenderer);
+		fadeObject->AddBehaviour(fade);
 
 		return false;
 	}

--- a/src/Game/ResultScene/GameOverScene/GameOverScene.cpp
+++ b/src/Game/ResultScene/GameOverScene/GameOverScene.cpp
@@ -27,46 +27,52 @@ namespace Game { namespace ResultScene
 
 		using Texture = GameEngine::Resource::Texture;
 		using ResourceManager = GameEngine::Resource::ResourceManager;
-		GameEngine::GameObject* ManagerObject = GameEngine::GameObject::Instantiate();
+
+		// マネージャー用
+		GameEngine::GameObject* resultManagerObject = GameEngine::GameObject::Instantiate();
 		auto resultmanager = new Game::ResultManager();
-		ManagerObject->AddBehaviour(resultmanager);
+		auto resultManagerSoundPlay = new GameEngine::Behaviour::SoundPlay();
+		resultManagerSoundPlay->SetSound(GameEngine::Sound::Sound::CreateFromWaveFile("./data/sound/game_over.wav", XAUDIO2_LOOP_INFINITE));
+		resultManagerObject->AddBehaviour(resultmanager);
+		resultManagerObject->AddBehaviour(resultManagerSoundPlay);
+		resultManagerSoundPlay->Play();
+
+		// ゲームオーバー画面の背景用
+		GameEngine::GameObject* backgroundObject = GameEngine::GameObject::Instantiate();
+		backgroundObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
+		backgroundObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
+		auto backgroundRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/GAME_OVER_BG.png"));
+		backgroundRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+		backgroundObject->AddBehaviour(backgroundRenderer);
 
 
-		GameEngine::GameObject* BackgroundObject = GameEngine::GameObject::Instantiate();
-		BackgroundObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
-		BackgroundObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
-		auto backGroundRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/GAME_OVER_BG.png"));
-		backGroundRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
-		BackgroundObject->AddBehaviour(backGroundRenderer);
-
-
-		GameEngine::GameObject* GameOverObject = GameEngine::GameObject::Instantiate();
-		GameOverObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 200.0f, 0.0f));
-		GameOverObject->GetTransform()->SetScale(&D3DXVECTOR3(600.0f, 150.0f, 50.0f));
-		auto GameOverRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/GAME_OVER.png"));
-		GameOverRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
-		GameOverObject->AddBehaviour(GameOverRenderer);
+		GameEngine::GameObject* gameoverObject = GameEngine::GameObject::Instantiate();
+		gameoverObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 200.0f, 0.0f));
+		gameoverObject->GetTransform()->SetScale(&D3DXVECTOR3(600.0f, 150.0f, 50.0f));
+		auto gameoverRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/GAME_OVER.png"));
+		gameoverRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+		gameoverObject->AddBehaviour(gameoverRenderer);
 
 
 		// PushEnter用
-		GameEngine::GameObject* PushEnterObject = GameEngine::GameObject::Instantiate();
-		PushEnterObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 450.0f, 0.0f));
-		PushEnterObject->GetTransform()->SetScale(&D3DXVECTOR3(400.0f, 300.0f, 50.0f));
+		GameEngine::GameObject* pushenterObject = GameEngine::GameObject::Instantiate();
+		pushenterObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 400.0f, 0.0f));
+		pushenterObject->GetTransform()->SetScale(&D3DXVECTOR3(400.0f, 300.0f, 50.0f));
 		auto flash = new Game::Flash();
-		auto PushEnterRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/pushenter.png"));
-		PushEnterObject->AddBehaviour(flash);
-		PushEnterRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
-		PushEnterObject->AddBehaviour(PushEnterRenderer);
+		auto pushenterRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/pushenter.png"));
+		pushenterObject->AddBehaviour(flash);
+		pushenterRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+		pushenterObject->AddBehaviour(pushenterRenderer);
 
 		// フェード用
-		GameEngine::GameObject* FadeObject = GameEngine::GameObject::Instantiate();
-		FadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
-		FadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
+		GameEngine::GameObject* fadeObject = GameEngine::GameObject::Instantiate();
+		fadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
+		fadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
 		auto fade = new Game::Fade();
-		auto FadeRenderer = new GameEngine::Behaviour::UIRenderer();
-		FadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
-		FadeObject->AddBehaviour(FadeRenderer);
-		FadeObject->AddBehaviour(fade);
+		auto fadeRenderer = new GameEngine::Behaviour::UIRenderer();
+		fadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
+		fadeObject->AddBehaviour(fadeRenderer);
+		fadeObject->AddBehaviour(fade);
 
 		return false;
 	}

--- a/src/Game/ResultScene/StageClearScene/StageClearManager.cpp
+++ b/src/Game/ResultScene/StageClearScene/StageClearManager.cpp
@@ -27,7 +27,6 @@ namespace Game { namespace ResultScene
 	//===============================================
 	void StageClearManager::Start()
 	{
-		//_render = this->GetAttachedObject()->FindBehaviour<GameEngine::Behaviour::UIRenderer>();
 
 	}
 

--- a/src/Game/ResultScene/StageClearScene/StageClearScene.cpp
+++ b/src/Game/ResultScene/StageClearScene/StageClearScene.cpp
@@ -29,46 +29,52 @@ namespace Game {
 
 			using Texture = GameEngine::Resource::Texture;
 			using ResourceManager = GameEngine::Resource::ResourceManager;
-			GameEngine::GameObject* ManagerObject = GameEngine::GameObject::Instantiate();
-			auto stageclearmanager = new Game::ResultScene::StageClearManager ();
-			ManagerObject->AddBehaviour(stageclearmanager);
+
+			// マネージャー用
+			GameEngine::GameObject* stageclearManagerObject = GameEngine::GameObject::Instantiate();
+			auto resultmanager = new Game::ResultManager();
+			auto stageclearManagerSoundPlay = new GameEngine::Behaviour::SoundPlay();
+			stageclearManagerSoundPlay->SetSound(GameEngine::Sound::Sound::CreateFromWaveFile("./data/sound/stage_clear.wav", XAUDIO2_LOOP_INFINITE));
+			stageclearManagerObject->AddBehaviour(resultmanager);
+			stageclearManagerObject->AddBehaviour(stageclearManagerSoundPlay);
+			stageclearManagerSoundPlay->Play();
 
 
-			GameEngine::GameObject* BackgroundObject = GameEngine::GameObject::Instantiate();
-			BackgroundObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
-			BackgroundObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
-			auto backGroundRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/STAGE_CLEAR_BG.png"));
-			backGroundRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
-			BackgroundObject->AddBehaviour(backGroundRenderer);
+			GameEngine::GameObject* backgroundObject = GameEngine::GameObject::Instantiate();
+			backgroundObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
+			backgroundObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
+			auto backgroundRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/STAGE_CLEAR_BG.png"));
+			backgroundRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+			backgroundObject->AddBehaviour(backgroundRenderer);
 
 
-			GameEngine::GameObject* StageClearObject = GameEngine::GameObject::Instantiate();
-			StageClearObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 200.0f, 0.0f));
-			StageClearObject->GetTransform()->SetScale(&D3DXVECTOR3(600.0f, 150.0f, 50.0f));
-			auto StageClearRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/STAGE_CLEAR.png"));
-			StageClearRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
-			StageClearObject->AddBehaviour(StageClearRenderer);
+			GameEngine::GameObject* stageclearObject = GameEngine::GameObject::Instantiate();
+			stageclearObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 200.0f, 0.0f));
+			stageclearObject->GetTransform()->SetScale(&D3DXVECTOR3(600.0f, 150.0f, 50.0f));
+			auto stageclearRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/STAGE_CLEAR.png"));
+			stageclearRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+			stageclearObject->AddBehaviour(stageclearRenderer);
 
 
 			// PushEnter用
-			GameEngine::GameObject* PushEnterObject = GameEngine::GameObject::Instantiate();
-			PushEnterObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 450.0f, 0.0f));
-			PushEnterObject->GetTransform()->SetScale(&D3DXVECTOR3(400.0f, 300.0f, 50.0f));
+			GameEngine::GameObject* pushenterObject = GameEngine::GameObject::Instantiate();
+			pushenterObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 400.0f, 0.0f));
+			pushenterObject->GetTransform()->SetScale(&D3DXVECTOR3(400.0f, 300.0f, 50.0f));
 			auto flash = new Game::Flash();
-			auto PushEnterRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/pushenter.png"));
-			PushEnterObject->AddBehaviour(flash);
-			PushEnterRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
-			PushEnterObject->AddBehaviour(PushEnterRenderer);
+			auto pushenterRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/pushenter.png"));
+			pushenterObject->AddBehaviour(flash);
+			pushenterRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+			pushenterObject->AddBehaviour(pushenterRenderer);
 
 			// フェード用
-			GameEngine::GameObject* FadeObject = GameEngine::GameObject::Instantiate();
-			FadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
-			FadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
+			GameEngine::GameObject* fadeObject = GameEngine::GameObject::Instantiate();
+			fadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
+			fadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
 			auto fade = new Game::Fade();
-			auto FadeRenderer = new GameEngine::Behaviour::UIRenderer();
-			FadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
-			FadeObject->AddBehaviour(FadeRenderer);
-			FadeObject->AddBehaviour(fade);
+			auto fadeRenderer = new GameEngine::Behaviour::UIRenderer();
+			fadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
+			fadeObject->AddBehaviour(fadeRenderer);
+			fadeObject->AddBehaviour(fade);
 
 			return false;
 		}

--- a/src/Game/TitleScene/TitleScene.cpp
+++ b/src/Game/TitleScene/TitleScene.cpp
@@ -29,76 +29,76 @@ bool TitleScene::Init()
 	using ResourceManager	= GameEngine::Resource::ResourceManager;
 
 	// 背景の描画
-	GameEngine::GameObject* BackgroundObject = GameEngine::GameObject::Instantiate();
-	BackgroundObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
-	BackgroundObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
-	auto backGroundRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/titlebackground.png"));
-	backGroundRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
-	BackgroundObject->AddBehaviour(backGroundRenderer);
+	GameEngine::GameObject* backgroundObject = GameEngine::GameObject::Instantiate();
+	backgroundObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
+	backgroundObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
+	auto backgroundRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/titlebackground.png"));
+	backgroundRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+	backgroundObject->AddBehaviour(backgroundRenderer);
 
 
-	GameEngine::GameObject* TitlemanagerObject = GameEngine::GameObject::Instantiate();
-	TitlemanagerObject->GetTransform()->SetPosition(&D3DXVECTOR3(300.0f, 400.0f, 0.0f));
-	TitlemanagerObject->GetTransform()->SetScale(&D3DXVECTOR3(50.0f, 50.0f, 50.0f));
-	auto titlemanager = new Game::TitleManager();
-	auto TitlemanagerRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/select.png"));
+	GameEngine::GameObject* titleManagerObject = GameEngine::GameObject::Instantiate();
+	titleManagerObject->GetTransform()->SetPosition(&D3DXVECTOR3(300.0f, 400.0f, 0.0f));
+	titleManagerObject->GetTransform()->SetScale(&D3DXVECTOR3(50.0f, 50.0f, 50.0f));
+	auto titleManager = new Game::TitleManager();
+	auto titleManagerRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/select.png"));
 	auto titleManagerSoundPlay = new GameEngine::Behaviour::SoundPlay();
-	TitlemanagerRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+	titleManagerRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
 	titleManagerSoundPlay->SetSound(GameEngine::Sound::Sound::CreateFromWaveFile("./data/sound/title.wav",XAUDIO2_LOOP_INFINITE));
-	TitlemanagerObject->AddBehaviour(TitlemanagerRenderer);
-	TitlemanagerObject->AddBehaviour(titlemanager);
-	TitlemanagerObject->AddBehaviour(titleManagerSoundPlay);
+	titleManagerObject->AddBehaviour(titleManagerRenderer);
+	titleManagerObject->AddBehaviour(titleManager);
+	titleManagerObject->AddBehaviour(titleManagerSoundPlay);
 	titleManagerSoundPlay->Play();
 
 	// タイトルの描画
-	GameEngine::GameObject* TitleObject = GameEngine::GameObject::Instantiate();
-	TitleObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
-	TitleObject->GetTransform()->SetScale(&D3DXVECTOR3(600.0f, 150.0f, 50.0f));
-	auto TitleRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/title.png"));
-	TitleRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
-	TitleObject->AddBehaviour(TitleRenderer);
+	GameEngine::GameObject* titleObject = GameEngine::GameObject::Instantiate();
+	titleObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
+	titleObject->GetTransform()->SetScale(&D3DXVECTOR3(600.0f, 150.0f, 50.0f));
+	auto titleRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/title.png"));
+	titleRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+	titleObject->AddBehaviour(titleRenderer);
 
 	// チュートリアルの文字の表示
-	GameEngine::GameObject* StageObject = GameEngine::GameObject::Instantiate();
-	StageObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 400.0f, 0.0f));
-	StageObject->GetTransform()->SetScale(&D3DXVECTOR3(250.0f, 70.0f, 50.0f));
-	auto StageRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/tutorial.png"));
-	StageRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
-	StageObject->AddBehaviour(StageRenderer);
+	GameEngine::GameObject* stageObject = GameEngine::GameObject::Instantiate();
+	stageObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 400.0f, 0.0f));
+	stageObject->GetTransform()->SetScale(&D3DXVECTOR3(250.0f, 70.0f, 50.0f));
+	auto stageRenderer = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/tutorial.png"));
+	stageRenderer->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+	stageObject->AddBehaviour(stageRenderer);
 
 	// ステージ１の文字の表示
-	GameEngine::GameObject* StageObject2 = GameEngine::GameObject::Instantiate();
-	StageObject2->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 450.0f, 0.0f));
-	StageObject2->GetTransform()->SetScale(&D3DXVECTOR3(250.0f, 70.0f, 50.0f));
-	auto StageRenderer2 = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/stage1.png"));
-	StageRenderer2->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
-	StageObject2->AddBehaviour(StageRenderer2);
+	GameEngine::GameObject* stageObject2 = GameEngine::GameObject::Instantiate();
+	stageObject2->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 450.0f, 0.0f));
+	stageObject2->GetTransform()->SetScale(&D3DXVECTOR3(250.0f, 70.0f, 50.0f));
+	auto stageRenderer2 = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/stage1.png"));
+	stageRenderer2->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+	stageObject2->AddBehaviour(stageRenderer2);
 
 	// ステージ２の文字の表示
-	GameEngine::GameObject* StageObject3 = GameEngine::GameObject::Instantiate();
-	StageObject3->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 500.0f, 0.0f));
-	StageObject3->GetTransform()->SetScale(&D3DXVECTOR3(250.0f, 70.0f, 50.0f));
-	auto StageRenderer3 = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/stage2.png"));
-	StageRenderer3->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
-	StageObject3->AddBehaviour(StageRenderer3);
+	GameEngine::GameObject* stageObject3 = GameEngine::GameObject::Instantiate();
+	stageObject3->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 500.0f, 0.0f));
+	stageObject3->GetTransform()->SetScale(&D3DXVECTOR3(250.0f, 70.0f, 50.0f));
+	auto stageRenderer3 = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/stage2.png"));
+	stageRenderer3->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+	stageObject3->AddBehaviour(stageRenderer3);
 
 	// ステージ３の文字の表示
-	GameEngine::GameObject* StageObject4 = GameEngine::GameObject::Instantiate();
-	StageObject4->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 550.0f, 0.0f));
-	StageObject4->GetTransform()->SetScale(&D3DXVECTOR3(250.0f, 70.0f, 50.0f));
-	auto StageRenderer4 = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/stage3.png"));
-	StageRenderer4->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
-	StageObject4->AddBehaviour(StageRenderer4);
+	GameEngine::GameObject* stageObject4 = GameEngine::GameObject::Instantiate();
+	stageObject4->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 550.0f, 0.0f));
+	stageObject4->GetTransform()->SetScale(&D3DXVECTOR3(250.0f, 70.0f, 50.0f));
+	auto stageRenderer4 = new GameEngine::Behaviour::UIRenderer(GameEngine::Resource::ResourceManager::Get<Texture>("./data/texture/stage3.png"));
+	stageRenderer4->SetColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+	stageObject4->AddBehaviour(stageRenderer4);
 
 	// フェード用
-	GameEngine::GameObject* FadeObject = GameEngine::GameObject::Instantiate();
-	FadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
-	FadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
+	GameEngine::GameObject* fadeObject = GameEngine::GameObject::Instantiate();
+	fadeObject->GetTransform()->SetPosition(&D3DXVECTOR3(400.0f, 300.0f, 0.0f));
+	fadeObject->GetTransform()->SetScale(&D3DXVECTOR3(800.0f, 600.0f, 50.0f));
 	auto fade = new Game::Fade();
-	auto FadeRenderer = new GameEngine::Behaviour::UIRenderer();
-	FadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
-	FadeObject->AddBehaviour(FadeRenderer);
-	FadeObject->AddBehaviour(fade);
+	auto fadeRenderer = new GameEngine::Behaviour::UIRenderer();
+	fadeRenderer->SetColor(D3DCOLOR_ARGB(255, 0, 0, 0));
+	fadeObject->AddBehaviour(fadeRenderer);
+	fadeObject->AddBehaviour(fade);
 	return false;
 }
 


### PR DESCRIPTION
ステージのBGM、ステージクリアのBGM、ゲームクリアのBGM、ゲームオーバーのBGMの追加。
ローカル変数のリネーム。
フェードの色を黒だとステージの色と被るので灰色っぽっく修正（許可取得済み）。
GameClearSceneのGemeClearのテクスチャがないため、代わりにStageClearのテクスチャを使用しています。届き次第直します。